### PR TITLE
The external dependency examples had the wrong group name and no names

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'com.bertramlabs.plugins.asset-pipeline-gradle:2.0.6'
-    classpath 'com.bertramlabs.plugins.coffee-asset-pipeline:2.0.6'
+    classpath 'com.bertramlabs.plugins:asset-pipeline-gradle:2.1.1'
+    classpath 'com.bertramlabs.plugins:coffee-asset-pipeline:2.0.6'
   }
 }
 ```


### PR DESCRIPTION
The example which was provided in the README file had the wrong group name/external dependency format.
